### PR TITLE
Default datetime format handle

### DIFF
--- a/SystemManagamentLib/Shared/DateTimeHelper.cs
+++ b/SystemManagamentLib/Shared/DateTimeHelper.cs
@@ -23,6 +23,11 @@ namespace SystemManagament.Shared
                 }
             }
 
+            if (DateTime.TryParse(dateAsString, out DateTime dateTimeDefaultValue))
+            {
+                return dateTimeDefaultValue;
+            }
+            
             return default(DateTime);
         }
     }


### PR DESCRIPTION
Due to multiple format datetime, you can add a fallback for datime to get the system format.